### PR TITLE
Fix stack distribution issues

### DIFF
--- a/ngc/FormGenerator.fs
+++ b/ngc/FormGenerator.fs
@@ -5,11 +5,8 @@ open System.Collections.Generic
 open System.Reflection
 open System.Reflection.Emit
 open Naggum.Runtime
-open Naggum.Compiler.Globals
-open Naggum.Compiler.Reader
 open Naggum.Compiler.Context
 open Naggum.Compiler.IGenerator
-open Naggum.Util.MaybeMonad
 open Naggum.Compiler.Reader
 
 type FormGenerator() =
@@ -59,27 +56,34 @@ type SequenceGenerator(context:Context,typeBuilder:TypeBuilder,seq:SExp list, gf
         member this.ReturnTypes () =
             List.map (fun (sexp) -> List.head ((gf.MakeGenerator context sexp).ReturnTypes())) seq
 
-type BodyGenerator(context:Context,typeBuilder:TypeBuilder,body:SExp list, gf:IGeneratorFactory) =
-    member private this.gen_body (ilGen:ILGenerator,body:SExp list) =
+type BodyGenerator(context : Context,
+                   methodBuilder : MethodBuilder,
+                   body : SExp list,
+                   gf : IGeneratorFactory) =
+    let rec genBody (ilGen : ILGenerator) (body : SExp list) =
         match body with
             | [] ->
                 ilGen.Emit(OpCodes.Ldnull)
             | [last] ->
                 let gen = gf.MakeGenerator context last
-                let val_type = gen.ReturnTypes()
+                let stackType = Seq.head <| gen.ReturnTypes ()
+                let returnType = methodBuilder.ReturnType
                 gen.Generate ilGen
-                if ((List.head val_type) = typeof<System.Void>) then
-                    ilGen.Emit(OpCodes.Ldnull)
+                match (stackType, returnType) with
+                | (s, r) when s = typeof<Void> && r = typeof<Void> -> ()
+                | (s, r) when s = typeof<Void> && r <> typeof<Void> -> ilGen.Emit OpCodes.Ldnull
+                | (s, r) when s <> typeof<Void> && r = typeof<Void> -> ilGen.Emit OpCodes.Pop
+                | _ -> ()
             | sexp :: rest ->
                 let gen = gf.MakeGenerator context sexp
                 let val_type = gen.ReturnTypes()
                 gen.Generate ilGen
-                if not (List.head val_type = typeof<System.Void>) then
+                if List.head val_type <> typeof<Void> then
                     ilGen.Emit(OpCodes.Pop)
-                this.gen_body (ilGen,rest)
+                genBody ilGen rest
     interface IGenerator with
-        member this.Generate ilGen = 
-            this.gen_body (ilGen,body)
+        member __.Generate ilGen = 
+            genBody ilGen body
         member this.ReturnTypes () =
             match body with
             |[] -> [typeof<System.Void>]
@@ -89,7 +93,12 @@ type BodyGenerator(context:Context,typeBuilder:TypeBuilder,body:SExp list, gf:IG
                     [typeof<obj>]
                 else tail_type
 
-type LetGenerator(context:Context,typeBuilder:TypeBuilder,bindings:SExp,body:SExp list,gf:IGeneratorFactory) =
+type LetGenerator(context : Context,
+                  typeBuilder : TypeBuilder,
+                  methodBuilder : MethodBuilder,
+                  bindings:SExp,
+                  body : SExp list,
+                  gf : IGeneratorFactory) =
     interface IGenerator with
         member this.Generate ilGen =
             ilGen.BeginScope()
@@ -107,7 +116,7 @@ type LetGenerator(context:Context,typeBuilder:TypeBuilder,bindings:SExp,body:SEx
                         ilGen.Emit (OpCodes.Stloc,local)
                     | other -> failwithf "In let bindings: Expected: (name (form))\nGot: %A\n" other
             | other -> failwithf "In let form: expected: list of bindings\nGot: %A" other
-            let bodyGen = (new BodyGenerator (scope_subctx,typeBuilder,body,gf) :> IGenerator)
+            let bodyGen = new BodyGenerator (scope_subctx, methodBuilder, body, gf) :> IGenerator
             bodyGen.Generate ilGen
             ilGen.EndScope()
         member this.ReturnTypes () =
@@ -181,7 +190,8 @@ type DefunGenerator(context:Context,typeBuilder:TypeBuilder,fname:string,paramet
                                                     let parm_idx = (List.findIndex (fun (p) -> p = parm) parameters)
                                                     fun_ctx.locals.[new Symbol(parm_name)] <- Arg (parm_idx,arg_types.[parm_idx])
                                                 | other -> failwithf "In function %A parameter definition:\nExpected: Atom(Symbol)\nGot: %A" fname parm
-                                            let bodyGen = gf.MakeBody fun_ctx body
+                                            let methodFactory = gf.MakeGeneratorFactory typeBuilder methodGen
+                                            let bodyGen = methodFactory.MakeBody fun_ctx body
                                             bodyGen.Generate methodILGen
                                             methodILGen.Emit(OpCodes.Ret)
                                             methodGen :> MethodInfo)
@@ -249,7 +259,6 @@ type TypeGenerator(context : Context, typeBuilder : TypeBuilder, typeName : stri
             Globals.ModuleBuilder.DefineType(typeName, TypeAttributes.Class ||| TypeAttributes.Public, typeof<obj>)
         else
             Globals.ModuleBuilder.DefineType(typeName, TypeAttributes.Class ||| TypeAttributes.Public, context.types.[new Symbol(parentTypeName)])
-    let newGeneratorFactory = gf.MakeGeneratorFactory newTypeBuilder
     let mutable fields : string list = []
 
     let generate_field field_name =
@@ -266,6 +275,7 @@ type TypeGenerator(context : Context, typeBuilder : TypeBuilder, typeName : stri
                 let parm_idx = (List.findIndex (fun (p) -> p = parm) method_parms)
                 method_ctx.locals.[new Symbol(parm_name)] <- Arg (parm_idx,typeof<obj>)
             | other -> failwithf "In method %A%A parameter definition:\nExpected: Atom(Symbol)\nGot: %A" typeName method_name parm
+        let newGeneratorFactory = gf.MakeGeneratorFactory newTypeBuilder method_gen
         let body_gen = newGeneratorFactory.MakeBody method_ctx method_body
         body_gen.Generate (method_gen.GetILGenerator())
         (method_gen.GetILGenerator()).Emit(OpCodes.Ret)

--- a/ngc/Generator.fs
+++ b/ngc/Generator.fs
@@ -2,17 +2,12 @@
 
 open System
 open System.IO
-open System.Collections.Generic
 open System.Reflection
 open System.Reflection.Emit
 
-open Naggum.Compiler.Globals
 open Naggum.Compiler.IGenerator
 open Naggum.Compiler.GeneratorFactory
 open Naggum.Compiler.Reader
-open Naggum.Runtime
-
-open Context
 
 let private prologue (ilGen : ILGenerator) =
     ilGen.BeginScope()
@@ -38,9 +33,12 @@ let compile (source : Stream) (assemblyName : string) (fileName : string) (asmRe
     let assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Save)
     Globals.ModuleBuilder <- assemblyBuilder.DefineDynamicModule(assemblyBuilder.GetName().Name, fileName)
     let typeBuilder = Globals.ModuleBuilder.DefineType("Program", TypeAttributes.Public ||| TypeAttributes.Class ||| TypeAttributes.BeforeFieldInit)
-    let methodBuilder = typeBuilder.DefineMethod("Main", MethodAttributes.Public ||| MethodAttributes.Static, typeof<int>, [| |])
+    let methodBuilder = typeBuilder.DefineMethod ("Main",
+                                                  MethodAttributes.Public ||| MethodAttributes.Static,
+                                                  typeof<Void>,
+                                                  Array.Empty ())
     
-    let gf = new GeneratorFactory(typeBuilder) :> IGeneratorFactory
+    let gf = new GeneratorFactory(typeBuilder, methodBuilder) :> IGeneratorFactory
     assemblyBuilder.SetEntryPoint methodBuilder
     
     let context = Context.create ()

--- a/ngc/IGenerator.fs
+++ b/ngc/IGenerator.fs
@@ -1,7 +1,6 @@
 ﻿module Naggum.Compiler.IGenerator
 
 open System
-open System.Reflection
 open System.Reflection.Emit
 
 open Naggum.Compiler.Reader
@@ -19,5 +18,5 @@ type IGeneratorFactory =
         abstract MakeGenerator : Context -> SExp -> IGenerator
         abstract MakeSequence : Context -> SExp list -> IGenerator
         abstract MakeBody : Context -> SExp list -> IGenerator
-        abstract MakeGeneratorFactory : TypeBuilder -> IGeneratorFactory
+        abstract MakeGeneratorFactory : TypeBuilder -> MethodBuilder -> IGeneratorFactory
     end


### PR DESCRIPTION
This PR fixes two issues that caused invalid stack distribution and compiled program termination on Mono (see #25).

First, the invalid `ldnull; ret` sequence was generated for `int Main()` method. I've replaced `int Main` with `void Main` for now and removed the final `ldnull` generation for any void-returning methods.

(We'll review the possible ways of defining `Main` method signatures later, but currently it's the simplest solution to fix the bug.)

Second, invalid stack distribution was generated by so-called "reduced if" form generator (the `if` statement with only one branch) if the branch contained only `void` instructions: `ngc` created dummy `ldnull` instruction for the missing branch that caused stack imbalance. I've removed that `ldnull` for cases when there is only a void-typed expression in the reduced if body. There are other possible bugs with structural (e.g. `int`, `float` etc.) types there, but we'll sort that later.

Closes #25.