### PR TITLE
License: update authors and copyright year

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright (C) 2011—2015 by F. von Never, Hagane
+Copyright (C) 2011—2016 by Naggum authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Replaces author names with "Naggum authors" collective entity, updates copyright year as discussed in #43. Closes #43.

I'll review it myself later (because I'm the only copyright holder active in project now).