### PR TITLE
Test culture insensivity and bug fixes

### DIFF
--- a/Naggum.Backend/Reader.fs
+++ b/Naggum.Backend/Reader.fs
@@ -41,7 +41,7 @@ let string =
     let normalChar = satisfy (fun c -> c <> '\"')
     between (pstring "\"") (pstring "\"") (manyChars normalChar) |>> (fun str -> str :> obj) |>> Object
 
-let symChars = (anyOf "+-*/=<>!?.") //chars that are valid in the symbol name
+let symChars = (anyOf "+-*/=<>!?._") //chars that are valid in the symbol name
 let symbol = (many1Chars (letter <|> digit <|> symChars)) |>> Symbol
 let atom = (pnumber <|> string <|> symbol) |>> Atom
 let listElement = choice [ atom; list ]

--- a/Naggum.Compiler/GeneratorFactory.fs
+++ b/Naggum.Compiler/GeneratorFactory.fs
@@ -48,12 +48,11 @@ type GeneratorFactory(typeBuilder : TypeBuilder,
         | [Symbol "if"; condition; if_true] -> // reduced if form
             new ReducedIfGenerator(context,typeBuilder,condition,if_true,this) :> IGenerator
         | Symbol "let" :: bindings :: body -> // let form
-            new LetGenerator(context,
-                             typeBuilder,
-                             methodBuilder,
-                             bindings,
-                             body,
-                             this) :> IGenerator
+            upcast new LetGenerator(context,
+                                    typeof<Void>,
+                                    bindings,
+                                    body,
+                                    this)
         | [Symbol "quote"; quotedExp] ->
             new QuoteGenerator(context,typeBuilder,quotedExp,this) :> IGenerator
         | Symbol "new" :: Symbol typeName :: args ->
@@ -102,10 +101,7 @@ type GeneratorFactory(typeBuilder : TypeBuilder,
         new SequenceGenerator(context,typeBuilder,seq,(this :> IGeneratorFactory))
 
     member private this.makeBodyGenerator(context: Context,body:SExp list) =
-        new BodyGenerator(context,
-                          methodBuilder,
-                          body,
-                          (this :> IGeneratorFactory))
+        new BodyGenerator(context, methodBuilder.ReturnType, body, this)
 
     interface IGeneratorFactory with
         member this.MakeGenerator context sexp =

--- a/Naggum.Compiler/Naggum.Compiler.fsproj
+++ b/Naggum.Compiler/Naggum.Compiler.fsproj
@@ -28,7 +28,7 @@
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\Naggum.Compiler.XML</DocumentationFile>
-    <StartArguments>..\tests\test.naggum</StartArguments>
+    <StartArguments>..\..\..\tests\test.naggum</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Naggum.Test/CompilerTest.fs
+++ b/Naggum.Test/CompilerTest.fs
@@ -12,9 +12,9 @@ type CompilerTest() =
     static let testExtension = "naggum"
     static let resultExtension = "result"
     static let executableExtension = "exe"
-    
+
     static let directory = Path.Combine ("..", "..", "..", "tests")
-    static let filenames = [@"comment"; @"test"]
+    static let filenames = [@"comment"; @"test"; "let-funcall"]
 
     static member private RunTest testName =
         let basePath = Path.Combine(directory, testName)

--- a/Naggum.sln
+++ b/Naggum.sln
@@ -7,6 +7,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test programs", "Test progr
 	ProjectSection(SolutionItems) = preProject
 		tests\comment.naggum = tests\comment.naggum
 		tests\comment.result = tests\comment.result
+		tests\let-funcall.naggum = tests\let-funcall.naggum
+		tests\let-funcall.result = tests\let-funcall.result
 		tests\test.naggum = tests\test.naggum
 		tests\test.result = tests\test.result
 	EndProjectSection

--- a/tests/let-funcall.naggum
+++ b/tests/let-funcall.naggum
@@ -1,0 +1,12 @@
+(defun test-let ()
+  (System.Console.Write "Let: ")
+  (let ((ok "OK"))
+    (System.Console.WriteLine ok)))
+(System.Console.WriteLine "Naggum test suite")
+
+(let ((thread (System.Threading.Thread.get_CurrentThread))
+      (culture (System.Globalization.CultureInfo.get_InvariantCulture)))
+    (System.Console.WriteLine "Setting up an environment...")
+    (call set_CurrentCulture thread culture))
+
+(test-let)

--- a/tests/let-funcall.result
+++ b/tests/let-funcall.result
@@ -1,0 +1,3 @@
+Naggum test suite
+Setting up an environment...
+Let: OK

--- a/tests/test.naggum
+++ b/tests/test.naggum
@@ -56,6 +56,11 @@
 
 (System.Console.WriteLine "Naggum test suite")
 
+(let ((thread (System.Threading.Thread.get_CurrentThread))
+      (culture (System.Globalization.CultureInfo.get_InvariantCulture)))
+    (System.Console.WriteLine "Setting up an environment...")
+    (call set_CurrentCulture thread culture))
+
 (test-funcall "OK")
 (test-conditionals)
 (test-let)

--- a/tests/test.result
+++ b/tests/test.result
@@ -1,4 +1,5 @@
 Naggum test suite
+Setting up an environment...
 Functions: OK
 Conditionals:
 Reduced if: OK


### PR DESCRIPTION
In my quest to fix #24 I've encountered some compiler bugs regarding to the `let` expressions and have exterminated these bugs.

The main problem I fixed is that `BodyGenerator` was used both in context of a function body and in context of a `let` clause body. In first context its return type should be based on a function return type (as we already discussed in #26, it shouldn't return anything when compiling a `void` function).

Now the `BodyGenerator` always receives (hopefully) the right return type definition, so the machinery added in #26 will make a good decisions about whether to return something or not.

Closes #24.