### PR TITLE
Assembler: infer file names for saved assemblies

### DIFF
--- a/Naggum.Assembler/Assembler.fs
+++ b/Naggum.Assembler/Assembler.fs
@@ -52,7 +52,7 @@ let assemble (mode : AssemblyBuilderAccess) (assembly : Assembly) =
     let name = AssemblyName assembly.Name
     let domain = AppDomain.CurrentDomain
     let builder = domain.DefineDynamicAssembly (name, mode)
-    let fileName = assembly.Name + ".dll" // TODO: Proper file naming
+    let fileName = assembly.Name + ".exe" // TODO: Proper file naming
     let moduleBuilder = builder.DefineDynamicModule (assembly.Name, fileName)
     assembly.Units |> List.iter (assembleUnit builder moduleBuilder)
     moduleBuilder.CreateGlobalFunctions ()

--- a/Naggum.Assembler/Program.fs
+++ b/Naggum.Assembler/Program.fs
@@ -19,7 +19,7 @@ let private printError (error : Exception) =
     printfn "Error: %s" (error.ToString ())
 
 let private save (assembly : AssemblyBuilder) =
-    let name = assembly.FullName
+    let name = assembly.GetName().Name + ".exe" // TODO: See #45. ~ F
     assembly.Save name
     printfn "Assembly %s saved" name
 


### PR DESCRIPTION
I've found that we're trying to use so-called "assembly name" as a file name in `Naggum.Assembler.Program`. Assembly name is not defined in terms of files or paths, it's just kind of identifier. For example, assembly may be named "Hello, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null". That's a valid file path, but not the kind we want to.

Also I've changed the Assembler to generate `.exe` files by default; that's more useful for testing.

Now assembly naming is consistent between `Naggum.Compiler` and `Naggum.Assembler` although it's not finished yet; see #45.

This will close #64.