### PR TITLE
Better NixOS 16.03 development environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,13 @@ with import <nixpkgs> {}; rec {
   naggumEnv = stdenv.mkDerivation {
     name = "naggum";
     buildInputs = [ mono fsharp dotnetPackages.Nuget ];
+
+    # For more info regarding this variable see:
+    # https://github.com/NixOS/nixpkgs/blob/d4681bf62672083f92545e02e00b8cf040247e8d/pkgs/build-support/dotnetbuildhelpers/patch-fsharp-targets.sh
     FSharpTargetsPath="${fsharp}/lib/mono/${frameworkVersion}/Microsoft.FSharp.Targets";
+
+    # For more info regarding this variable see:
+    # http://www.mono-project.com/docs/advanced/assemblies-and-the-gac/
     MONO_PATH="${fsharp}/lib/mono/Reference Assemblies/Microsoft/FSharp/.NETFramework/v${fsharpVersion}/${assemblyVersion}/";
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+with import <nixpkgs> {}; rec {
+  frameworkVersion = "4.5";
+  fsharpVersion = "4.0";
+  assemblyVersion = "4.4.0.0";
+
+  naggumEnv = stdenv.mkDerivation {
+    name = "naggum";
+    buildInputs = [ mono fsharp dotnetPackages.Nuget ];
+    FSharpTargetsPath="${fsharp}/lib/mono/${frameworkVersion}/Microsoft.FSharp.Targets";
+    MONO_PATH="${fsharp}/lib/mono/Reference Assemblies/Microsoft/FSharp/.NETFramework/v${fsharpVersion}/${assemblyVersion}/";
+  };
+}

--- a/docs/build-guide.rst
+++ b/docs/build-guide.rst
@@ -27,34 +27,16 @@ add instructions for any other distributions.
 NixOS Linux
 ^^^^^^^^^^^
 
-First of all, install ``mono``, ``fsharp`` and ``dotnetPackages.Nuget``::
+Enter the development environment::
 
-    $ nix-env -i mono fsharp
-    $ nix-env -iA nixos.pkgs.dotnetPackages.Nuget
-
-Please note that you need ``fsharp`` >= 4.0 to build Naggum, which is currently
-in the unstable channel. So maybe you'll need to switch to the unstable channel
-or build ``fsharp`` from `Nixpkgs`_ source.
-
-According to the recommendations in `patch-fsharp-targets`_ build helper,
-you may want to set up the environment variable ``FSharpTargetsPath`` either
-globally or locally::
-
-    $ export FSharpTargetsPath=$(dirname $(which fsharpc))/../lib/mono/4.5/Microsoft.FSharp.Targets
+    $ cd naggum
+    $ nix-shell
 
 After that you can download the dependencies and build the project using
 ``xbuild``::
 
-    $ cd naggum
     $ nuget restore
     $ xbuild /p:Configuration=Release /p:TargetFrameworkVersion="v4.5"
-
-After that you should copy ``FSharp.Core.dll`` to the project output directory,
-because currently Nix have problems with concept of Mono global assembly cache::
-
-    $ FSHARP_CORE=$HOME/.nix-profile/lib/mono/Reference\ Assemblies/Microsoft/\
-    FSharp/.NETFramework/v4.0/4.4.0.0/FSharp.Core.dll
-    $ echo Naggum.*/bin/Release | xargs -n 1 cp -f "$FSHARP_CORE"
 
 After that, you can run ``Naggum.Compiler``, for example::
 

--- a/docs/build-guide.rst
+++ b/docs/build-guide.rst
@@ -58,8 +58,6 @@ html`` (on Linux) or ``.\make.bat html`` (on Windows).
 .. _F# Compiler: http://fsharp.org/
 .. _Mono: http://www.mono-project.com/
 .. _NixOS Linux: http://nixos.org/
-.. _Nixpkgs: https://github.com/NixOS/nixpkgs
 .. _NuGet: http://www.nuget.org/
-.. _patch-fsharp-targets:  https://github.com/NixOS/nixpkgs/blob/d4681bf62672083f92545e02e00b8cf040247e8d/pkgs/build-support/dotnetbuildhelpers/patch-fsharp-targets.sh
 .. _Python: https://www.python.org/
 .. _Sphinx: http://sphinx-doc.org/

--- a/docs/build-guide.rst
+++ b/docs/build-guide.rst
@@ -27,8 +27,7 @@ add instructions for any other distributions.
 NixOS Linux
 ^^^^^^^^^^^
 
-*The instructions has been verified on NixOS 16.03. If something
- doesn't work, please file an issue.*
+*The instructions have been verified on NixOS 16.03. If something doesn't work, please file an issue.*
 
 Enter the development environment::
 

--- a/docs/build-guide.rst
+++ b/docs/build-guide.rst
@@ -27,6 +27,9 @@ add instructions for any other distributions.
 NixOS Linux
 ^^^^^^^^^^^
 
+*The instructions has been verified on NixOS 16.03. If something
+ doesn't work, please file an issue.*
+
 Enter the development environment::
 
     $ cd naggum


### PR DESCRIPTION
Checked on NixOS 16.03. Unstable is not required anymore for Naggum to be built. Updated the guide and created the default.nix.

Close #72 
Close #71 